### PR TITLE
Fix addEvent.js loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <script type="text/javascript" src="/resources/js/default/main.js"></script>
   <script type="text/javascript" src="/resources/js/default/includeHtml.js"></script>
   <script type="text/javascript" src="/resources/js/default/luckyNumber.js"></script>
-  <script type="text/javascript" src="/resources/js/default/addEvent.js" async></script>
+  <script type="text/javascript" src="/resources/js/default/addEvent.js" defer></script>
   <script type="text/javascript" src="/resources/js/default/color.js" defer></script>
   <script type="text/javascript" src="/resources/js/default/weather.js" defer></script>
   <script type="text/javascript" src="/resources/js/app/momontom.js" defer></script>
@@ -29,6 +29,6 @@
   <nav in-ht="nav"></nav>
   <section class="setFadeIn" in-ht="main"></section>
   <footer in-ht="footer"></footer>
-  <script type="text/javascript" src="/resources/js/ready.js" async></script>
+  <script type="text/javascript" src="/resources/js/ready.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use `defer` when loading **addEvent.js** and **ready.js** to ensure `fnReady()` is defined before `includeHTML()` runs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fbacbebd08330a8b8329895bab207