### PR TITLE
Fix alt text for vacuum cleaner image

### DIFF
--- a/views/app/sprtGpt.html
+++ b/views/app/sprtGpt.html
@@ -68,7 +68,7 @@
         </div>
         <div class="col-md-4 mb-4">
             <div class="card">
-                <img src="/resources/img/app/sprtGpt/청소기.jpeg" class="card-img-top" alt="노트북">
+                <img src="/resources/img/app/sprtGpt/청소기.jpeg" class="card-img-top" alt="청소기">
                 <div class="card-body">
                     <h5 class="card-title">청소기</h5>
                     <h6 class="card-subtitle mb-2 text-muted">55만원</h6>


### PR DESCRIPTION
## Summary
- correct the `alt` text on the last product card in `sprtGpt.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685fbc86860083309499e178bbd946e1