### PR TITLE
Fix month display in footer clock

### DIFF
--- a/resources/js/default/main.js
+++ b/resources/js/default/main.js
@@ -130,7 +130,7 @@ const goHref = (a,b,c)=>{
  */
 const setClock = ()=>{
     let nowDate = new Date();
-    return nowDate.getFullYear() + "년 " + nowDate.getMonth() + "월 " + nowDate.getDate() + "일 " + nowDate.getHours() + "시 " + nowDate.getMinutes() + "분 " + nowDate.getSeconds() + "초";
+    return nowDate.getFullYear() + "년 " + (nowDate.getMonth() + 1) + "월 " + nowDate.getDate() + "일 " + nowDate.getHours() + "시 " + nowDate.getMinutes() + "분 " + nowDate.getSeconds() + "초";
 }
 
 /**


### PR DESCRIPTION
## Summary
- add 1 to `getMonth()` when building the footer clock string

## Testing
- `npm test` *(fails: no test specified)*
- `node - <<'EOF'
function setClock(){
    let nowDate = new Date('2025-06-15T00:00:00');
    return nowDate.getFullYear() + "년 " + (nowDate.getMonth() + 1) + "월 " + nowDate.getDate() + "일 " + nowDate.getHours() + "시 " + nowDate.getMinutes() + "분 " + nowDate.getSeconds() + "초";
}
console.log(setClock());
EOF

------
https://chatgpt.com/codex/tasks/task_e_685fbe5ed6b48330b4eb36ce5086e631