### PR TITLE
Refactor sprtGpt HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,16 @@
   <link rel="stylesheet" type="text/css" href="/resources/css/main.css"/>
   <link rel="stylesheet" type="text/css" href="/resources/css/app/momontom.css"/>
   <link rel="stylesheet" type="text/css" href="/resources/css/app/calculator.css"/>
+  <link rel="stylesheet" href="https://s3.ap-northeast-2.amazonaws.com/materials.spartacodingclub.kr/easygpt/default.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+  <link rel="stylesheet" type="text/css" href="/resources/css/app/sprtGpt.css"/>
 
   <script type="text/javascript" src="/resources/js/default/main.js"></script>
   <script type="text/javascript" src="/resources/js/default/includeHtml.js"></script>
   <script type="text/javascript" src="/resources/js/default/luckyNumber.js"></script>
   <script type="text/javascript" src="/resources/js/default/addEvent.js" defer></script>
   <script type="text/javascript" src="/resources/js/default/color.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
   <script type="text/javascript" src="/resources/js/default/weather.js" defer></script>
   <script type="text/javascript" src="/resources/js/app/momontom.js" defer></script>
   <script type="text/javascript" src="/resources/js/app/calculator.js" defer></script>

--- a/resources/css/app/sprtGpt.css
+++ b/resources/css/app/sprtGpt.css
@@ -1,0 +1,13 @@
+.hero {
+    padding-bottom: 20px;
+}
+
+.card {
+    overflow: hidden;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    transition: transform 0.15s ease-in-out;
+}
+
+.card:hover {
+    transform: scale(1.05);
+}

--- a/views/app/sprtGpt.html
+++ b/views/app/sprtGpt.html
@@ -1,31 +1,3 @@
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>나만의 중고마켓</title>
-  <link rel="stylesheet"
-      href="https://s3.ap-northeast-2.amazonaws.com/materials.spartacodingclub.kr/easygpt/default.css">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
-      integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
-      crossorigin="anonymous"></script>
-  <style>
-      .hero {
-          padding-bottom: 20px;
-      }
-
-      .card {
-          overflow: hidden;
-          box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-          transition: transform 0.15s ease-in-out;
-      }
-
-      .card:hover {
-          transform: scale(1.05);
-      }
-  </style>
-</head>
-
 <article id="sprtGpt">
   <div class="hero bg-dark text-center py-5 py-md-4">
     <h1 class="text-white">old secondhand goods</h1>


### PR DESCRIPTION
## Summary
- remove `<head>` block from sprtGpt page
- move bootstrap and style refs into index.html
- extract sprtGpt styling into its own css file

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('views/app/sprtGpt.html','utf8');console.log(html.trim().startsWith('<article'));"`


------
https://chatgpt.com/codex/tasks/task_e_685fc009c5248330b5c4e027277a313b