### PR TITLE
Improve weather error handling and modernize theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <link rel="canonical" href="https://gabeujin.github.io" />
   <link rel="icon" type="image/x-icon" href="/resources/img/repo_favicon.ico">
   <link rel="stylesheet" type="text/css" href="/resources/css/main.css"/>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+  <link rel="stylesheet" type="text/css" href="/resources/css/theme.css"/>
   <link rel="stylesheet" type="text/css" href="/resources/css/app/momontom.css"/>
   <link rel="stylesheet" type="text/css" href="/resources/css/app/calculator.css"/>
   <link rel="stylesheet" href="https://s3.ap-northeast-2.amazonaws.com/materials.spartacodingclub.kr/easygpt/default.css">

--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -1,0 +1,60 @@
+:root {
+  --bg-color: #f8f9fa;
+  --primary-color: #343a40;
+  --accent-color: #0d6efd;
+  --text-color: #212529;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: 'Inter', sans-serif;
+  line-height: 1.6;
+}
+
+body>header {
+  background-color: var(--primary-color);
+  color: #fff;
+  padding: 1rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+body>header span {
+  font-size: 2.5rem;
+  text-shadow: none;
+  color: #fff;
+}
+
+body>nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background-color: #e9ecef;
+}
+
+body>nav>button {
+  background-color: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+}
+
+body>nav>button:hover {
+  background-color: #0b5ed7;
+}
+
+body>footer p {
+  background-color: #e9ecef;
+  padding: 0.5rem;
+}
+
+.toastAlert {
+  background-color: #343a40;
+  color: #fff;
+}

--- a/resources/js/default/weather.js
+++ b/resources/js/default/weather.js
@@ -12,6 +12,9 @@ const GEO_APIKEY  =
 
 if (!GEO_APIKEY) {
   console.error("Weather API key is not configured. Set WEATHER_API_KEY in weatherConfig.js or as an environment variable.");
+  if (window.getFeature && getFeature.getToast) {
+    getFeature.getToast("날씨 정보를 불러올 수 없습니다");
+  }
 }
 //////////////////////
 
@@ -23,14 +26,20 @@ function setGeoTemp(obj){
   }
 }
 
-function getWeather(obj){
-  fetch(
-    `https://api.openweathermap.org/data/2.5/onecall?lat=${obj.lat}&lon=${obj.long}&appid=${GEO_APIKEY}&units=metric`
-    ).then(function(res){
-        return res.json();
-    }).then(function(json){
-      setGeoTemp(json);
-    });
+async function getWeather(obj){
+  try{
+    const res = await fetch(
+      `https://api.openweathermap.org/data/2.5/onecall?lat=${obj.lat}&lon=${obj.long}&appid=${GEO_APIKEY}&units=metric`
+    );
+    if(!res.ok) throw new Error('Weather fetch failed');
+    const json = await res.json();
+    setGeoTemp(json);
+  } catch(err){
+    console.error(err);
+    if (window.getFeature && getFeature.getToast) {
+      getFeature.getToast('날씨 정보를 불러오지 못했습니다');
+    }
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- apply modern theme styles using new CSS file
- load Inter font and theme styles in index
- show toast message when weather API key is missing or weather fetch fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685fb81e54e083309d250d81916ba9d8