### PR TITLE
Improve navigation layout

### DIFF
--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -30,13 +30,19 @@ body>header span {
 
 body>nav {
   display: flex;
-  justify-content: center;
-  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
   padding: 0.5rem;
   background-color: #e9ecef;
 }
 
-body>nav>button {
+body>nav .external-links {
+  display: flex;
+  gap: 0.5rem;
+}
+
+body>nav .external-links button {
   background-color: var(--accent-color);
   color: #fff;
   border: none;
@@ -45,8 +51,28 @@ body>nav>button {
   cursor: pointer;
 }
 
-body>nav>button:hover {
+body>nav .external-links button:hover {
   background-color: #0b5ed7;
+}
+
+body>nav .app-links {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+body>nav .app-links a {
+  text-decoration: none;
+  color: var(--text-color);
+  padding: 0.3rem 0.75rem;
+  border-radius: 0.25rem;
+}
+
+body>nav .app-links a:hover {
+  background-color: var(--accent-color);
+  color: #fff;
 }
 
 body>footer p {
@@ -58,3 +84,4 @@ body>footer p {
   background-color: #343a40;
   color: #fff;
 }
+

--- a/views/header.html
+++ b/views/header.html
@@ -1,2 +1,3 @@
-<h1 class="pageTitle"><span title="homepageTitle">Memory Repo</span></h1>
+<h1 class="pageTitle"><a href="/" title="homepageTitle"><span>Memory Repo</span></a></h1>
 <p title="MIT license">MIT License _ Copyright (c) 2020 Gabeujin</p>
+

--- a/views/nav.html
+++ b/views/nav.html
@@ -1,10 +1,14 @@
-<button id="issueLink" title="linked to 'gabeujin' github">issue?</button>
-<button id="lhTest" title="linked to 'lighthouse' github">lighthouseTest</button>
-<button id="charsets" title="linked to 'charset' w3schools">charsets</button>
-<div>
-  <div>
-    <!-- <form class="srchForm" method="post" target="_top" onSubmit="return getFeature.getToast('준비중입니다');">
-      <input type="search" name="search" placeholder="" required/>
-      <input type="submit" value="Go!"/>
-  </form> -->
-</div>
+<nav class="main-nav">
+  <div class="external-links">
+    <button id="issueLink" title="linked to 'gabeujin' github">issue?</button>
+    <button id="lhTest" title="linked to 'lighthouse' github">lighthouseTest</button>
+    <button id="charsets" title="linked to 'charset' w3schools">charsets</button>
+  </div>
+  <ul class="app-links">
+    <li><a href="#" onclick="goHref('app/animal-test');return false;">Animal Test</a></li>
+    <li><a href="#" onclick="goHref('app/fruit-test');return false;">Fruit Test</a></li>
+    <li><a href="#" onclick="goHref('app/momontom');return false;">Momontom</a></li>
+    <li><a href="#" onclick="goHref('app/calculator');return false;">Calculator</a></li>
+    <li><a href="#" onclick="goHref('app/sprtGpt');return false;">SprtGPT</a></li>
+  </ul>
+</nav>


### PR DESCRIPTION
## Summary
- simplify header markup and link the site title to home
- redesign navigation markup for clarity and easier access to apps
- style new navigation with flexbox

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685fc848f2fc8330976dc3803350bd88