### PR TITLE
Add interactive app launch and window controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <meta name="Description" content="IT, HTML, JAVASCRIPT, GITHUBPAGE, TIP, LICENSE, INFOMATION OTHERS.." />
   <script type="text/javascript" src="/resources/js/config/appList.js"></script>
   <script type="text/javascript" src="/resources/js/default/main.js"></script>
+  <script type="text/javascript" src="/resources/js/default/appManager.js"></script>
 
   <link rel="canonical" href="https://gabeujin.github.io" />
   <link rel="icon" type="image/x-icon" href="/resources/img/repo_favicon.ico">

--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -159,5 +159,46 @@ body > section .app-grid {
 }
 
 .app-card button:hover {
-	background-color: #0b5ed7;
+        background-color: #0b5ed7;
+}
+
+/* --- app launch overlay --- */
+.app-launch-overlay {
+        position: absolute;
+        background: #fff;
+        border-radius: 0.5rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+        z-index: 200;
+        transition: all 0.4s ease-in-out;
+}
+
+.app-launch-overlay.expand {
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border-radius: 0;
+}
+
+.window-controls {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        display: flex;
+        gap: 0.3rem;
+        z-index: 50;
+}
+
+.window-controls button {
+        width: 1.5rem;
+        height: 1.5rem;
+        line-height: 1.5rem;
+        font-size: 1rem;
+        border: none;
+        background: #ccc;
+        cursor: pointer;
+}
+
+.window-controls button:hover {
+        background: #bbb;
 }

--- a/resources/js/app/momontom.js
+++ b/resources/js/app/momontom.js
@@ -189,7 +189,7 @@ function momontomInit() {
 
   //init D-day setting. 시계 설정 및 1초마다 반복 실행 interval 설정.
   getTime();
-  INTERVAL_ARR.push(setInterval(getTime, 1000));
+  AppManager.addInterval(setInterval(getTime, 1000));
 
   //할일(localStorage) 을 변수로 담기 = 초기화
   if(usrTodo !== null){

--- a/resources/js/config/appList.js
+++ b/resources/js/config/appList.js
@@ -2,7 +2,7 @@ window.APP_LIST = [
   { id: 1, name: 'fruit-test', script: null, css: null, init: null },
   { id: 2, name: 'animal-test', script: null, css: null, init: null },
   { id: 3, name: 'coding-study', script: null, css: null, init: null },
-  { id: 4, name: 'momontom', script: '/resources/js/app/momontom.js', css: '/resources/css/app/momontom.css', init: 'momontomInit' },
-  { id: 5, name: 'calculator', script: '/resources/js/app/calculator.js', css: '/resources/css/app/calculator.css', init: 'calculatorInit' },
+  { id: 4, name: 'momontom', script: '/resources/js/app/momontom.js', css: '/resources/css/app/momontom.css', init: 'momontomInit', lsKeys: ['USERNM','TODOLIST','COORDS'] },
+  { id: 5, name: 'calculator', script: '/resources/js/app/calculator.js', css: '/resources/css/app/calculator.css', init: 'calculatorInit', lsKeys: ['PREVNUM','OPER','NEXTNUM','TEMP'] },
   { id: 6, name: 'sprtGpt', script: null, css: '/resources/css/app/sprtGpt.css', init: null }
 ];

--- a/resources/js/default/appManager.js
+++ b/resources/js/default/appManager.js
@@ -1,0 +1,48 @@
+(function(){
+  window.AppManager = {
+    current: null,
+    apps: {},
+    register: function(name, element, opt){
+      if(!this.apps[name]) this.apps[name] = {element:null, intervals:[], lsKeys:[]};
+      if(element) this.apps[name].element = element;
+      if(opt && Array.isArray(opt.lsKeys)) this.apps[name].lsKeys = opt.lsKeys;
+      this.current = name;
+    },
+    addInterval: function(id){
+      if(this.current && this.apps[this.current]){
+        this.apps[this.current].intervals.push(id);
+      }
+    },
+    clearIntervals: function(name){
+      var app = this.apps[name];
+      if(app){
+        app.intervals.forEach(function(i){ clearInterval(i); });
+        app.intervals = [];
+      }
+    },
+    clearStorage: function(name){
+      var app = this.apps[name];
+      if(app && app.lsKeys){
+        app.lsKeys.forEach(function(k){ localStorage.removeItem(k); });
+      }
+    },
+    minimize: function(){
+      var controls = document.querySelector('.window-controls');
+      if(controls) controls.remove();
+      ContentClear();
+      includeSection();
+      this.current = null;
+    },
+    close: function(){
+      var name = this.current;
+      if(!name) return;
+      this.clearIntervals(name);
+      this.clearStorage(name);
+      var controls = document.querySelector('.window-controls');
+      if(controls) controls.remove();
+      ContentClear();
+      includeSection();
+      this.current = null;
+    }
+  };
+})();

--- a/resources/js/default/includeHtml.js
+++ b/resources/js/default/includeHtml.js
@@ -70,7 +70,7 @@ let includePage = (file)=>{
       if (this.status == 200) {
         z.innerHTML = this.responseText;
         const article = z.querySelector("article");
-        if(article) includeJsInit(article.id);
+        if(article) includeJsInit(article);
       }
       else if (this.status == 403) {
         return false;
@@ -92,9 +92,9 @@ xhttp.send();
 return;
 }
 
-const includeJsInit = async (appId) => {
-  if(!appId) return;
-  const appName = appId.replace(/app/g,'').replace(/^./, a => a.toLowerCase());
+const includeJsInit = async (article) => {
+  if(!article) return;
+  const appName = article.id.replace(/app/g,'').replace(/^./, a => a.toLowerCase());
   const info = APP_LIST.find(a => a.name === appName);
   if(!info) return;
 
@@ -117,6 +117,10 @@ const includeJsInit = async (appId) => {
       document.body.appendChild(s);
     });
   }
+
+  AppManager.register(appName, article, { lsKeys: info.lsKeys });
+
+  showWindowControls();
 
   if(typeof window[info.init] === 'function'){
     window[info.init]();

--- a/resources/js/default/main.js
+++ b/resources/js/default/main.js
@@ -46,8 +46,13 @@ const _useYn = function(a){
    * @description delete all interval. (전역)interval 전부 삭제
    */
   const _stopAllInterval = function(){
-    for ( let i = 0; i < INTERVAL_ARR.length; i++ )
-      clearInterval(INTERVAL_ARR[i]);
+    if(AppManager && AppManager.current){
+      AppManager.clearIntervals(AppManager.current);
+    } else if(Array.isArray(INTERVAL_ARR)) {
+      for ( let i = 0; i < INTERVAL_ARR.length; i++ )
+        clearInterval(INTERVAL_ARR[i]);
+      INTERVAL_ARR = [];
+    }
   };
   
   
@@ -281,15 +286,15 @@ const getFeature = {
         btn.textContent = "S T A R T";
         btn.type        = "button";
         btn.addEventListener("click", e => {
-            e.stopPropagation(); 
-            if( link.textContent.indexOf("www") > -1 )
-                goHref("https://"+link.textContent.trim(),"_blank");
-            else
-                goHref(link.textContent.trim() + ".html");
-            //getFeature.getToast("준비중입니다.");
-            
+            e.stopPropagation();
+            const url = link.textContent.trim();
+            if( url.indexOf("www") > -1 ){
+                goHref("https://"+url,"_blank");
+            }else{
+                const card = e.currentTarget.closest('.app-card');
+                launchApp(card, url + ".html");
+            }
         });
-        //addevent
         return btn;
     },
      /**
@@ -319,3 +324,42 @@ const getFeature = {
 
 
 }
+const launchApp = (card, page) => {
+    const section = document.querySelector('body>section');
+    if(!section){
+        goHref(page);
+        return;
+    }
+    const rect = card.getBoundingClientRect();
+    const secRect = section.getBoundingClientRect();
+    const overlay = document.createElement('div');
+    overlay.className = 'app-launch-overlay';
+    overlay.style.top = (rect.top - secRect.top) + 'px';
+    overlay.style.left = (rect.left - secRect.left) + 'px';
+    overlay.style.width = rect.width + 'px';
+    overlay.style.height = rect.height + 'px';
+    section.appendChild(overlay);
+    requestAnimationFrame(()=> overlay.classList.add('expand'));
+    overlay.addEventListener('transitionend', () => {
+        if(overlay.parentNode) overlay.parentNode.removeChild(overlay);
+        goHref(page);
+    }, {once:true});
+};
+
+const showWindowControls = () => {
+    const section = document.querySelector('body>section');
+    if(!section) return;
+    let controls = section.querySelector('.window-controls');
+    if(controls) controls.remove();
+    controls = document.createElement('div');
+    controls.className = 'window-controls';
+    const min = document.createElement('button');
+    min.textContent = '—';
+    const close = document.createElement('button');
+    close.textContent = '×';
+    min.addEventListener('click', () => AppManager.minimize());
+    close.addEventListener('click', () => AppManager.close());
+    controls.appendChild(min);
+    controls.appendChild(close);
+    section.appendChild(controls);
+};


### PR DESCRIPTION
## Summary
- implement `AppManager` for per-app resource handling
- add script to index.html
- add app storage info in `appList`
- animate app launch from card to full screen
- provide minimize and close buttons via `showWindowControls`
- track intervals per app in `momontom` and clear with `_stopAllInterval`
- style overlay and controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68600407fd2483308c61bb72c1e371bb